### PR TITLE
Update 2020-7-31-mixins.md

### DIFF
--- a/_posts/tutorials/2020-7-31-mixins.md
+++ b/_posts/tutorials/2020-7-31-mixins.md
@@ -35,6 +35,17 @@ apply plugin: 'net.minecraftforge.gradle'
 apply plugin: 'org.spongepowered.mixin'
 ```
 
+If you're using the new `plugins` DSL, you just need to add `id 'org.spongepowered.mixin' version '0.7.+'` onto your plugins block:
+
+```groovy
+plugins {
+    id 'eclipse'
+    id 'maven-publish'
+    id 'net.minecraftforge.gradle' version '5.1.+'
+    id 'org.spongepowered.mixin' version '0.7.+'
+}
+```
+
 Now that the plugin is applied to your build script you can configure the plugin. This involves setting up the generation of a a refmap which is used by Mixin to map your changes to different Minecraft environments and telling MixinGradle the name of your Mixin config file. For the refmap, you just need to define the source set to generate mappings for and the name of the file to output to. It is common practice to use `modid.refmap.json`. For the Mixin config file, it is common to use `modid.mixins.json`.
 
 ```groovy


### PR DESCRIPTION
Now that MixinGradle has plugin markers, adding MixinGradle with the plugins DSL is much easier. Thus, I added that to the tutorial page.

I can add a link to the gradle plugins dsl if needed!

Let me know if there's anything else.